### PR TITLE
Fix for uninitialized constant Forwardable

### DIFF
--- a/lib/middleman/pagination/extension_context.rb
+++ b/lib/middleman/pagination/extension_context.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Middleman
   module Pagination
     class ExtensionContext


### PR DESCRIPTION
I get the following error when running middleman with the
middleman-pagination plugin installed:

    uninitialized constant Middleman::Pagination::ExtensionContext::Forwardable (NameError)

Here is a fix.